### PR TITLE
feat: Extend the How to use guide in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ This library can collect various device and user data, forwarding it to a specif
 ### Option A - Using a custom Application implementation
 
 You can check out the Example app in this project for a working example. The application needs to
-either use the provided TrapApplication as the `android:name` value for the `<application>` tag in
-the AndroidManifest.xml, or subclass TrapApplication if you also need to use a custom Application
-class. Configuration is done via a `<meta-data>` tag within the `<application>` tag.
+either use the provided `TrapApplication` as the `android:name` value for the `<application>` tag in
+the `AndroidManifest.xml`, or subclass `TrapApplication` if you also need to use a custom 
+`Application` class. Configuration is done via a `<meta-data>` tag within the `<application>` tag.
 
 #### 1. Specify the application class
+
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
@@ -44,6 +45,7 @@ class. Configuration is done via a `<meta-data>` tag within the `<application>` 
 ```
 
 #### 2. (Optional) Use a custom config class
+
 Create the configuration provider implementation.
 
 ```kotlin
@@ -78,6 +80,7 @@ class MyConfig: TrapConfigProvider {
 ```
 
 Specify your configuration provider in the `AndroidManifest.xml`.
+
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
@@ -133,6 +136,7 @@ trapManager = TrapManager.getInstance(application, config)
 ```
 
 ### Ask for interactive permissions (if not previously requested) - in both cases
+
 ```kotlin
 if (!TrapBluetoothCollector.checkPermissions(activity)) {
     TrapBluetoothCollector.requirePermissions(activity) {

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ This library can collect various device and user data, forwarding it to a specif
 * Tap gesture
 
 ## How to use it
-You can check out the Example app in this project for a working example. The application needs to either use the provided TrapApplication as the 'android:name' value for the '<application>' tag in the AndroidManifest.xml, or subclass TrapApplication if you also need to use a custom Application class. Configuration is done via a '<meta-data>' tag within the '<application>' tag.
 
-### 1. Specify the application class
+### Option A - Using a custom Application implementation
+
+You can check out the Example app in this project for a working example. The application needs to
+either use the provided TrapApplication as the `android:name` value for the `<application>` tag in
+the AndroidManifest.xml, or subclass TrapApplication if you also need to use a custom Application
+class. Configuration is done via a `<meta-data>` tag within the `<application>` tag.
+
+#### 1. Specify the application class
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
@@ -37,7 +43,7 @@ You can check out the Example app in this project for a working example. The app
 </manifest>
 ```
 
-### 2. (Optional) Use a custom config class
+#### 2. (Optional) Use a custom config class
 Create the configuration provider implementation.
 
 ```kotlin
@@ -71,7 +77,7 @@ class MyConfig: TrapConfigProvider {
 }
 ```
 
-Specify your configuration provider in the 'AndroidManifest.xml'.
+Specify your configuration provider in the `AndroidManifest.xml`.
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
@@ -94,7 +100,39 @@ Specify your configuration provider in the 'AndroidManifest.xml'.
 </manifest>
 ```
 
-### 3. Ask for interactive permissions (if not previously requested)
+### Option B - Intialize TrapManager from code
+
+Execute the following code during application startup. Preferably in the `onCreate` method of the
+Application, by subclassing the default Android Application implementation. An alternative option
+can be to execute the code in the `onCreate` method of the main activity of the application, before ˛
+calling `super.onCreate()`.
+
+```kotlin
+val config = TrapConfig()
+config.reporter.url = "https://example.com/api/post/{streamId}/{sessionId}"
+
+// Use a special set of data collectors
+config.collectors = mutableListOf(TrapCoarseLocationCollector::class)
+
+// Set session id
+val file = File(application.filesDir, "my-session.id")
+if (!file.exists()) {
+    file.writeText(UUID.randomUUID().toString())
+}
+config.reporter.sessionId = UUID.fromString(file.readText())
+
+// Set session id
+val file = File(application.filesDir, "trap-session.id")
+if (!file.exists()) {
+    file.writeText(UUID.randomUUID().toString())
+}
+config.reporter.sessionId = UUID.fromString(file.readText())
+
+// Instantiate the TrapManager
+trapManager = TrapManager.getInstance(application, config)
+```
+
+### Ask for interactive permissions (if not previously requested) - in both cases
 ```kotlin
 if (!TrapBluetoothCollector.checkPermissions(activity)) {
     TrapBluetoothCollector.requirePermissions(activity) {


### PR DESCRIPTION
Add an option to use the app without using or extending the TrapApplication class.