### PR TITLE
feat: Make the automatic start of data collection configurable

### DIFF
--- a/trap/src/main/java/com/cursorinsight/trap/TrapConfig.kt
+++ b/trap/src/main/java/com/cursorinsight/trap/TrapConfig.kt
@@ -79,8 +79,13 @@ data class TrapConfig(
     /**
      * Battery charge threshold for low battery status
      */
-    var lowBatteryThreshold: Float = 10.0f
+    var lowBatteryThreshold: Float = 10.0f,
 
+    /**
+     * Is data collection enabled automatically when the TrapManager
+     * is instantiated with this config
+     */
+    var enableDataCollection: Boolean = true
 ) {
     /**
      * The configuration for the reporter task serializing

--- a/trap/src/main/java/com/cursorinsight/trap/TrapManager.kt
+++ b/trap/src/main/java/com/cursorinsight/trap/TrapManager.kt
@@ -130,6 +130,7 @@ class TrapManager internal constructor(
     }
 
     init {
+        isEnabled = config.enableDataCollection
         // Register the activity collection and lifecycle dispatch.
         application.registerActivityLifecycleCallbacks(this)
         val activity = currentActivity?.get()


### PR DESCRIPTION
Add a config option to TrapConfig that can change the default behaviour where the data collection was automatically enabled when the TrapManager was instantiated.